### PR TITLE
Update platform_strategy.py to support Python 2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ django-apptemplates==0.0.1
 django-suit==0.2.12
 boto==2.34.0
 mkdocs==0.11.1
+six==1.10.0

--- a/scarface/platform_strategy.py
+++ b/scarface/platform_strategy.py
@@ -35,7 +35,8 @@ def _import_strategy(path):
         mod = getattr(mod, comp)
     return mod
 
-class PlatformStrategy(metaclass=ABCMeta):
+class PlatformStrategy():
+    __metaclass__ = ABCMeta
 
     def __init__(self, platform_application):
         super().__init__()

--- a/scarface/platform_strategy.py
+++ b/scarface/platform_strategy.py
@@ -2,6 +2,7 @@
 import json
 from abc import ABCMeta, abstractproperty
 from copy import deepcopy
+from six import with_metaclass
 
 from django.conf import settings
 
@@ -35,8 +36,7 @@ def _import_strategy(path):
         mod = getattr(mod, comp)
     return mod
 
-class PlatformStrategy():
-    __metaclass__ = ABCMeta
+class PlatformStrategy(with_metaclass(ABCMeta)):
 
     def __init__(self, platform_application):
         super().__init__()


### PR DESCRIPTION
metaclass change in Python 3.x, but there are lot of projects still using Python 2.x, so for compatibility is good to change metaclass syntax
