### PR TITLE
Allow the use of a Platform getting the certificate from settings.py

### DIFF
--- a/scarface/models.py
+++ b/scarface/models.py
@@ -351,20 +351,22 @@ class Platform(SNSCRUDMixin, models.Model):
 
     @property
     def attributes(self):
+        credential = self.get_platform_credential()
+        principal = self.get_platform_principal()
         return {
-            "PlatformCredential": self.get_platform_credential(),
-            "PlatformPrincipal": self.get_platform_principal()
+            "PlatformCredential": credential,
+            "PlatformPrincipal": principal
         }
         
     def get_platform_credential(self):
-        if self.credential or self.credential != '':
+        if self.credential is not None and self.credential != '':
             return self.credential
         if hasattr(settings, 'SCARFACE_APNS_PRIVATE_KEY'):
             return settings.SCARFACE_APNS_PRIVATE_KEY
         return None
 
     def get_platform_principal(self):
-        if self.principal or self.principal != '':
+        if self.principal is not None and self.principal != '':
             return self.principal
         if hasattr(settings, 'SCARFACE_APNS_CERTIFICATE'):
             return settings.SCARFACE_APNS_CERTIFICATE

--- a/scarface/models.py
+++ b/scarface/models.py
@@ -4,6 +4,7 @@ import json
 from boto.exception import BotoServerError
 import re
 from django.db import models
+from django.conf import settings
 from scarface.platform_strategy import get_strategies
 from scarface.utils import DefaultConnection, PushLogger
 from scarface.exceptions import SNSNotCreatedException, PlatformNotSupported, \
@@ -351,9 +352,23 @@ class Platform(SNSCRUDMixin, models.Model):
     @property
     def attributes(self):
         return {
-            "PlatformCredential": self.credential,
-            "PlatformPrincipal": self.principal
+            "PlatformCredential": self.get_platform_credential(),
+            "PlatformPrincipal": self.get_platform_principal()
         }
+        
+    def get_platform_credential(self):
+        if self.credential or self.credential != '':
+            return self.credential
+        if hasattr(settings, 'SCARFACE_APNS_PRIVATE_KEY'):
+            return settings.SCARFACE_APNS_PRIVATE_KEY
+        return None
+
+    def get_platform_principal(self):
+        if self.principal or self.principal != '':
+            return self.principal
+        if hasattr(settings, 'SCARFACE_APNS_CERTIFICATE'):
+            return settings.SCARFACE_APNS_CERTIFICATE
+        return None
 
     @DefaultConnection
     def register(self, connection=None):


### PR DESCRIPTION
It was unclear from the docs how the settings described actually link up to using boto to make the necessary API calls with the correct credentials.

These changes allow settings to be used if the certificate credentials have not been applied to the model.

Do let me know if this is incorrect, if so the documentation needs to be updated to be clearer