### PR TITLE
Allow proper APS dictionary updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ target/
 .LSOverride
 Icon
 django_scarface/settings/local.py
+
+bin/
+pip-selfcheck.json
+pyvenv.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - pip install -q Django==$DJANGO
 
 before_script:
-  - psql -c 'CREATE USER django WITH superuser PASSWORD 'django''
+  - psql -c 'CREATE USER django WITH superuser PASSWORD 'django'' -U postgres
 
 #command to run the test suite
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - pip install -q Django==$DJANGO
 
 before_script:
-  - psql -c 'CREATE USER django WITH superuser PASSWORD 'django'' -U postgres
+  - psql -c "CREATE USER django WITH superuser PASSWORD 'django'" -U postgres
 
 #command to run the test suite
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+
+python:
+  - "3.6"
+
+services: postgres
+
+env:
+  global:
+    - DJANGO_SETTINGS_MODULE="django_scarface.settings.test"
+    - PIP_USE_MIRRORS=true
+    - BUILD_ON_TRAVIS=true
+  matrix:
+    - DJANGO=1.8 DB=postgres
+
+#commands to install dependencies
+install:
+  - pip install -q -r requirements.txt
+  - pip install -q Django==$DJANGO
+
+before_script:
+  - psql -c 'CREATE USER django WITH superuser PASSWORD 'django''
+
+#command to run the test suite
+script:
+  - python manage.py test

--- a/django_scarface/settings/base.py
+++ b/django_scarface/settings/base.py
@@ -125,7 +125,7 @@ TEMPLATE_DIRS = (
 )
 
 DJANGO_APPS = (
-    'suit',
+    # 'suit',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 Django==1.8
-psycopg2==2.5.4
+psycopg2
 django-jenkins==0.16.4
 pylint==1.4.0
 pep8==1.5.7
 django-apptemplates==0.0.1
-django-suit==0.2.12
 boto==2.34.0
 mkdocs==0.15.3
 six==1.10.0

--- a/scarface/platform_strategy.py
+++ b/scarface/platform_strategy.py
@@ -105,11 +105,12 @@ class APNPlatformStrategy(PlatformStrategy):
         )
 
         if message.extra_payload:
-            if 'aps' in message.extra_payload:
+            extra = message.extra_payload.copy()
+            if 'aps' in message.extra:
                 # Handle `aps` updating separately to not loose
                 # any alert props
-                payload['aps'].update(message.extra_payload.get('aps'))
-            payload.update(message.extra_payload)
+                payload['aps'].update(extra.pop('aps'))
+            payload.update(extra)
 
         return super(
             APNPlatformStrategy,

--- a/scarface/platform_strategy.py
+++ b/scarface/platform_strategy.py
@@ -106,7 +106,7 @@ class APNPlatformStrategy(PlatformStrategy):
 
         if message.extra_payload:
             extra = message.extra_payload.copy()
-            if 'aps' in message.extra:
+            if 'aps' in extra:
                 # Handle `aps` updating separately to not loose
                 # any alert props
                 payload['aps'].update(extra.pop('aps'))

--- a/scarface/platform_strategy.py
+++ b/scarface/platform_strategy.py
@@ -106,9 +106,9 @@ class APNPlatformStrategy(PlatformStrategy):
 
         if message.extra_payload:
             if 'aps' in message.extra_payload:
-                # Handle `aps` updating seperately to not loose
+                # Handle `aps` updating separately to not loose
                 # any alert props
-                payload['aps'].update(message.extra_payload.pop('aps'))
+                payload['aps'].update(message.extra_payload.get('aps'))
             payload.update(message.extra_payload)
 
         return super(


### PR DESCRIPTION
There are some notifications which require adding special flags to the `aps` dictionary, for example `"mutable-content": 1` (See #23).

This PR adds that functionality, while also making the tests pass on Travis-CI