### PR TITLE
Fix representation of the devices in terminal

### DIFF
--- a/scarface/models.py
+++ b/scarface/models.py
@@ -166,6 +166,9 @@ class Device(SNSCRUDMixin, models.Model):
     class Meta:
         unique_together = (('device_id', 'platform'))
 
+    def __str__(self):
+        return "{0} ({1})".format(self.device_id, self.platform)
+
     @property
     def resource_name(self):
         return 'PlatformEndpoint'


### PR DESCRIPTION
A simple fix to add a `__str__` method to the `Device` model